### PR TITLE
Allow for self-signed certificates to used (optionally)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ npm install passport-client-certificate
   Options:
     - `passReqToCallback`  when `true`, `req` is the first argument to the
        verify callback (default: `false`)
+    - `allowUnauthorized` when `true` allows self-signed or certificates from untrusted CAs to be accepted.
 
   Examples:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-client-certificate",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Passport middleware for client certificate authentication",
   "main": "index.js",
   "keywords": [

--- a/strategy.js
+++ b/strategy.js
@@ -44,7 +44,9 @@ class ClientCertStrategy extends Strategy {
   constructor (options, verify) {
     if (typeof options === 'function') {
       verify = options
-      options = {}
+      options = {
+        rejectUnauthorized: true
+      }
     }
     if (!verify) throw new Error('Client cert authentication strategy requires a verify function')
 
@@ -64,7 +66,7 @@ class ClientCertStrategy extends Strategy {
   authenticate (req, options) {
     // Requests must be authorized
     // (i.e. the certificate must be signed by at least one trusted CA)
-    if (!req.socket.authorized) {
+    if (!req.socket.authorized && options.rejectUnauthorized) {
       this.fail()
       return
     }

--- a/strategy.js
+++ b/strategy.js
@@ -44,11 +44,11 @@ class ClientCertStrategy extends Strategy {
   constructor (options, verify) {
     if (typeof options === 'function') {
       verify = options
-      options = {
-        rejectUnauthorized: true
-      }
+      options = {}
     }
     if (!verify) throw new Error('Client cert authentication strategy requires a verify function')
+    
+
 
     super()
 
@@ -66,7 +66,7 @@ class ClientCertStrategy extends Strategy {
   authenticate (req, options) {
     // Requests must be authorized
     // (i.e. the certificate must be signed by at least one trusted CA)
-    if (!req.socket.authorized && options.rejectUnauthorized) {
+    if (!req.socket.authorized && !options.allowUnauthorized) {
       this.fail()
       return
     }


### PR DESCRIPTION
Simple change to allow self-signed certificates to be used. Backwards compatible.

I chose `allowUnauthorized` because the node TLS option `rejectUnauthorized` is true by default, and I wanted the options here to false by default. 